### PR TITLE
Only apply appendOptionalSemicolon at the statement level

### DIFF
--- a/include/formatter.hpp
+++ b/include/formatter.hpp
@@ -156,7 +156,7 @@ private:
     std::optional<std::string> formatNode(AstNode* node);
     std::optional<std::string> formatNode(AstLocal* local);
 
-    size_t appendOptionalSemicolon(std::string& current, std::string& result, NodeTag& main_tag);
+    size_t appendOptionalSemicolon(std::string& current, std::string& result);
 
     bool canSimplifyRepeatBody(AstStatRepeat* main_stat, SimplifyResult& condition_simplified);
 


### PR DESCRIPTION
Fixes a case where `{ ({})[1] }` was being formatted as `{ ;({})[1] }`

There's probably a nicer way to write this fix, but I rarely write C++ code, so I've just gone with this